### PR TITLE
Search index

### DIFF
--- a/chatapp/app/controllers/room_controller.rb
+++ b/chatapp/app/controllers/room_controller.rb
@@ -6,6 +6,7 @@ class RoomController < ApplicationController
   def index
     @q = Room.ransack(params[:q])
     @results = @q.result.order(created_at: :DESC)
+    @room = Room.all.order(created_at: :DESC).limit(5)
   end
 
   def join
@@ -117,6 +118,7 @@ class RoomController < ApplicationController
   end
 
   def search_form
+    @room = Room.all.order(created_at: :DESC).limit(5)
     @q = Room.ransack(params[:q])
     @results = @q.result
   end

--- a/chatapp/app/controllers/room_controller.rb
+++ b/chatapp/app/controllers/room_controller.rb
@@ -116,6 +116,16 @@ class RoomController < ApplicationController
     @results = @q.result
   end
 
+  def search_form
+    @q = Room.ransack(params[:q])
+    @results = @q.result
+  end
+
+  def search_joined
+    @q = Room.ransack(params[:q])
+    @results = @q.result
+  end
+
   private
 
   def autocomplete_params

--- a/chatapp/app/views/layouts/application.html.erb
+++ b/chatapp/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
           <%= link_to "/", class: "menu-one" do %><i class="fa-solid fa-house"></i> トップ<% end %>
           <%= link_to "/room", class: "menu-one" do %><i class="fa-solid fa-comment"></i> ルーム一覧<% end %>
           <%= link_to "/room/joined", class: "menu-one" do %><i class="fa-solid fa-comment"></i> 参加中のルーム<% end %>
-          <%= link_to "/room", class: "menu-one" do %><i class="fa-solid fa-magnifying-glass"></i> ルームを探す<% end %>
+          <%= link_to "/search/rooms", class: "menu-one" do %><i class="fa-solid fa-magnifying-glass"></i> ルームを探す<% end %>
 
           <div class="menu-one" id="open-modal" name="open-modal-btn"><i class="fa-solid fa-plus"></i> ルームを作成</div>
 

--- a/chatapp/app/views/room/index.html.erb
+++ b/chatapp/app/views/room/index.html.erb
@@ -23,24 +23,6 @@
             <% end %>
             <%= link_to "参加", room_join_path(room.id) %>
         </div>
-    <% else %>
-        <div class="room"> 
-            <div class="room-image">
-              <% if room.image.length > 0 %>
-                <img src = "<%= room.image %>" class="room-image">
-              <% else %>
-                <img src = "/room_image/default.png" class="room-image">
-              <% end %>
-            </div>
-            <%= link_to room.name, room_page_path(room.id) %>
-            <% if room.created_at >= Date.today.beginning_of_day %>
-              今日<%= room.created_at.strftime("%H:%M") %>
-            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
-              昨日<%= room.created_at.strftime("%H:%M") %>
-            <% else %>
-              <%= room.created_at.strftime("%Y/%m/%d") %>
-            <% end %>
-        </div>
     <% end %>
   <% end %>
 </div>

--- a/chatapp/app/views/room/index.html.erb
+++ b/chatapp/app/views/room/index.html.erb
@@ -3,6 +3,53 @@
 </div>
 
 <div class="rooms">
+  <% @room.each do |room| %>
+    <% unless UserRoom.find_by(user_id: @current_user.id, room_id: room.id) %>
+        <div class="room"> 
+            <div class="room-image">
+              <% if room.image.length > 0 %>
+                <img src = "<%= room.image %>" class="room-image">
+              <% else %>
+                <img src = "/room_image/default.png" class="room-image">
+              <% end %>
+            </div>
+            <%= room.name %>
+            <% if room.created_at >= Date.today.beginning_of_day %>
+              今日<%= room.created_at.strftime("%H:%M") %>
+            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+              昨日<%= room.created_at.strftime("%H:%M") %>
+            <% else %>
+              <%= room.created_at.strftime("%Y/%m/%d") %>
+            <% end %>
+            <%= link_to "参加", room_join_path(room.id) %>
+        </div>
+    <% else %>
+        <div class="room"> 
+            <div class="room-image">
+              <% if room.image.length > 0 %>
+                <img src = "<%= room.image %>" class="room-image">
+              <% else %>
+                <img src = "/room_image/default.png" class="room-image">
+              <% end %>
+            </div>
+            <%= link_to room.name, room_page_path(room.id) %>
+            <% if room.created_at >= Date.today.beginning_of_day %>
+              今日<%= room.created_at.strftime("%H:%M") %>
+            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+              昨日<%= room.created_at.strftime("%H:%M") %>
+            <% else %>
+              <%= room.created_at.strftime("%Y/%m/%d") %>
+            <% end %>
+        </div>
+    <% end %>
+  <% end %>
+</div>
+
+<div class="content-column">
+  <div class="title">ルーム一覧</div>
+</div>
+
+<div class="rooms">
   <th><%= sort_link(@q, :created_at, "作成日", hide_indicator: true) %></th>
   <% @results.each do |room| %>
     <% unless UserRoom.find_by(user_id: @current_user.id, room_id: room.id) %>

--- a/chatapp/app/views/room/index.html.erb
+++ b/chatapp/app/views/room/index.html.erb
@@ -1,10 +1,3 @@
-<div class="search-area">
-  <%= search_form_for @q, url: room_search_path do |f| %>
-    <%= f.search_field :name_cont, placeholder: "キーワードを入力してルームを検索", required: true  %>
-    <% f.submit '検索' %>
-  <% end %>
-</div>
-
 <div class="content-column">
   <div class="title">最新ルーム</div>
 </div>

--- a/chatapp/app/views/room/joined.html.erb
+++ b/chatapp/app/views/room/joined.html.erb
@@ -1,6 +1,6 @@
 <div class="search-area">
-  <%= search_form_for @q, url: room_search_path do |f| %>
-    <%= f.search_field :name_cont, placeholder: "キーワードを入力してルームを検索", required: true  %>
+  <%= search_form_for @q, url: room_search_joined_path do |f| %>
+    <%= f.search_field :name_cont, placeholder: "キーワードを入力して参加済みのルームを検索", required: true  %>
     <% f.submit '検索' %>
   <% end %>
 </div>

--- a/chatapp/app/views/room/search.html.erb
+++ b/chatapp/app/views/room/search.html.erb
@@ -1,5 +1,45 @@
 「<%= @q.name_cont %>」の検索結果は<%= @results.count %>件です<br>
-<% @results.each do |room| %>
-    <%= room.name %>
-<% end %>
+<div class="rooms">
+  <% @results.each do |room| %>
+    <% if not UserRoom.find_by(user_id: @current_user.id, room_id: room.id) %>
+        <div class="room"> 
+            <div class="room-image">
+              <% if room.image.length > 0 %>
+                <img src = "<%= room.image %>" class="room-image">
+              <% else %>
+                <img src = "/room_image/default.png" class="room-image">
+              <% end %>
+            </div>
+            <%= room.name %>
+            <% if room.created_at >= Date.today.beginning_of_day %>
+              今日<%= room.created_at.strftime("%H:%M") %>
+            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+              昨日<%= room.created_at.strftime("%H:%M") %>
+            <% else %>
+              <%= room.created_at.strftime("%Y/%m/%d") %>
+            <% end %>
+            <%= link_to "参加", room_join_path(room.id) %>
+        </div>
+
+    <% else %>
+        <div class="room"> 
+            <div class="room-image">
+              <% if room.image.length > 0 %>
+                <img src = "<%= room.image %>" class="room-image">
+              <% else %>
+                <img src = "/room_image/default.png" class="room-image">
+              <% end %>
+            </div>
+            <%= link_to room.name, room_page_path(room.id) %>
+            <% if room.created_at >= Date.today.beginning_of_day %>
+              今日<%= room.created_at.strftime("%H:%M") %>
+            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+              昨日<%= room.created_at.strftime("%H:%M") %>
+            <% else %>
+              <%= room.created_at.strftime("%Y/%m/%d") %>
+            <% end %>
+        </div>
+    <% end %>
+  <% end %>
+</div>
 <%= link_to "戻る", "/room" %>

--- a/chatapp/app/views/room/search.html.erb
+++ b/chatapp/app/views/room/search.html.erb
@@ -1,7 +1,7 @@
 「<%= @q.name_cont %>」の検索結果は<%= @results.count %>件です<br>
 <div class="rooms">
   <% @results.each do |room| %>
-    <% if not UserRoom.find_by(user_id: @current_user.id, room_id: room.id) %>
+    <% unless UserRoom.find_by(user_id: @current_user.id, room_id: room.id) # not joined rooms %>
         <div class="room"> 
             <div class="room-image">
               <% if room.image.length > 0 %>
@@ -21,7 +21,7 @@
             <%= link_to "参加", room_join_path(room.id) %>
         </div>
 
-    <% else %>
+    <% else #joined rooms %>
         <div class="room"> 
             <div class="room-image">
               <% if room.image.length > 0 %>
@@ -42,4 +42,4 @@
     <% end %>
   <% end %>
 </div>
-<%= link_to "戻る", "/room" %>
+<%= link_to "戻る", "/search/rooms" %>

--- a/chatapp/app/views/room/search.html.erb
+++ b/chatapp/app/views/room/search.html.erb
@@ -22,23 +22,25 @@
         </div>
 
     <% else #joined rooms %>
-        <div class="room"> 
-            <div class="room-image">
-              <% if room.image.length > 0 %>
-                <img src = "<%= room.image %>" class="room-image">
-              <% else %>
-                <img src = "/room_image/default.png" class="room-image">
-              <% end %>
+        <%= link_to room_page_path(room.id) do %>
+            <div class="room"> 
+                <div class="room-image">
+                <% if room.image.length > 0 %>
+                    <img src = "<%= room.image %>" class="room-image">
+                <% else %>
+                    <img src = "/room_image/default.png" class="room-image">
+                <% end %>
+                </div>
+                <%= room.name %>
+                <% if room.created_at >= Date.today.beginning_of_day %>
+                今日<%= room.created_at.strftime("%H:%M") %>
+                <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+                昨日<%= room.created_at.strftime("%H:%M") %>
+                <% else %>
+                <%= room.created_at.strftime("%Y/%m/%d") %>
+                <% end %>
             </div>
-            <%= link_to room.name, room_page_path(room.id) %>
-            <% if room.created_at >= Date.today.beginning_of_day %>
-              今日<%= room.created_at.strftime("%H:%M") %>
-            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
-              昨日<%= room.created_at.strftime("%H:%M") %>
-            <% else %>
-              <%= room.created_at.strftime("%Y/%m/%d") %>
-            <% end %>
-        </div>
+        <% end %>
     <% end %>
   <% end %>
 </div>

--- a/chatapp/app/views/room/search_form.html.erb
+++ b/chatapp/app/views/room/search_form.html.erb
@@ -5,6 +5,55 @@
   <% end %>
 </div>
 
+<div class="content-column">
+  <div class="title">最新ルーム</div>
+</div>
+<div class="rooms">
+  <% @room.each do |room| %>
+    <% unless UserRoom.find_by(user_id: @current_user.id, room_id: room.id) #joined rooms %>
+        <div class="room"> 
+            <div class="room-image">
+              <% if room.image.length > 0 %>
+                <img src = "<%= room.image %>" class="room-image">
+              <% else %>
+                <img src = "/room_image/default.png" class="room-image">
+              <% end %>
+            </div>
+            <%= room.name %>
+            <% if room.created_at >= Date.today.beginning_of_day %>
+              今日<%= room.created_at.strftime("%H:%M") %>
+            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+              昨日<%= room.created_at.strftime("%H:%M") %>
+            <% else %>
+              <%= room.created_at.strftime("%Y/%m/%d") %>
+            <% end %>
+            <%= link_to "参加", room_join_path(room.id) %>
+        </div>
+
+    <% else #not joined rooms %>
+        <div class="room"> 
+            <div class="room-image">
+              <% if room.image.length > 0 %>
+                <img src = "<%= room.image %>" class="room-image">
+              <% else %>
+                <img src = "/room_image/default.png" class="room-image">
+              <% end %>
+            </div>
+            <%= link_to room.name, room_page_path(room.id) %>
+            <% if room.created_at >= Date.today.beginning_of_day %>
+              今日<%= room.created_at.strftime("%H:%M") %>
+            <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+              昨日<%= room.created_at.strftime("%H:%M") %>
+            <% else %>
+              <%= room.created_at.strftime("%Y/%m/%d") %>
+            <% end %>
+        </div>
+    <% end %>
+  <% end %>
+</div>
+
+
+
 
 <script type="text/javascript">
 $(function() {

--- a/chatapp/app/views/room/search_form.html.erb
+++ b/chatapp/app/views/room/search_form.html.erb
@@ -1,0 +1,29 @@
+<div class="search-area">
+  <%= search_form_for @q, url: room_search_path do |f| %>
+    <%= f.search_field :name_cont, placeholder: "キーワードを入力してルームを検索", required: true  %>
+    <% f.submit '検索' %>
+  <% end %>
+</div>
+
+
+<script type="text/javascript">
+$(function() {
+    const dataList = function(request, response) {
+      $.ajax({
+        url: '/name_auto/' + request.term,
+        dataType: 'json',
+        type: 'GET',
+        cache: true,
+        success: function(data) {
+          response(data);
+        },
+        error: function(XMLHttpRequest, textStatus, errorThrown) {
+          response(['']);
+        }
+      });
+    }
+    $("#q_name_cont").autocomplete({
+      source: dataList,
+    });
+});
+</script>

--- a/chatapp/app/views/room/search_joined.html.erb
+++ b/chatapp/app/views/room/search_joined.html.erb
@@ -1,0 +1,28 @@
+<p>参加していないルームは表示されません</p>
+<div class="rooms">
+  <% @results.each do |room| %>
+    <% if UserRoom.find_by(user_id: @current_user.id, room_id: room.id) %>
+        「<%= @q.name_cont %>」の検索結果は<%= @results.count %>件です<br>
+        <%= link_to room_page_path(room.id) do %>
+            <div class="room"> 
+                <div class="room-image">
+                <% if room.image.length > 0 %>
+                    <img src = "<%= room.image %>" class="room-image">
+                <% else %>
+                    <img src = "/room_image/default.png" class="room-image">
+                <% end %>
+                </div>
+                <%= room.name %>
+                <% if room.created_at >= Date.today.beginning_of_day %>
+                    今日<%= room.created_at.strftime("%H:%M") %>
+                <% elsif room.created_at < Date.today.beginning_of_day && room.created_at >= Date.yesterday.beginning_of_day%>
+                    昨日<%= room.created_at.strftime("%H:%M") %>
+                <% else %>
+                    <%= room.created_at.strftime("%Y/%m/%d") %>
+                <% end %>
+            </div>
+        <% end %>
+    <% end %>
+  <% end %>
+</div>
+<%= link_to "戻る", "/room/joined" %>

--- a/chatapp/config/routes.rb
+++ b/chatapp/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get "/room" => "room#index"
   get "/room/joined" => "room#joined"
   get "/search" => "room#search", as: :room_search
+  get "/search/rooms" => "room#search_form"
+  get "/search/join_rooms" => "room#search_joined", as: :room_search_joined
   get "/room/new" => "room#new_room", as: :new_room
   get "/room/:id" => "room#page", as: :room_page
   


### PR DESCRIPTION
ルームを探す ページを作成
ルームを探すページでは全ルームから検索、最新ルームを5件まで表示（参加、非参加どっちも）

ルーム一覧から検索機能を削除、　ルーム一覧上に最新ルーム（非参加ルーム）を5件まで表示 ←ちょっとおかしいかも
参加ルームページでは参加ルームからの検索を実装
