### PR TITLE
remake text-image desgin

### DIFF
--- a/chatapp/app/assets/stylesheets/room.scss
+++ b/chatapp/app/assets/stylesheets/room.scss
@@ -439,8 +439,10 @@
       padding: 15px 10px 15px 10px;
       margin-bottom: 10px;
       word-break: break-all;
-      img{
-        max-width: 90%;
+      .text-messeges{
+        img{
+          max-width: 56%;
+        }
       }
       .message-left {
         img{

--- a/chatapp/app/assets/stylesheets/room.scss
+++ b/chatapp/app/assets/stylesheets/room.scss
@@ -439,7 +439,7 @@
       padding: 15px 10px 15px 10px;
       margin-bottom: 10px;
       word-break: break-all;
-      .text-messeges{
+      .text-messages{
         img{
           max-width: 56%;
         }

--- a/chatapp/app/views/room/_messages.html.erb
+++ b/chatapp/app/views/room/_messages.html.erb
@@ -37,9 +37,9 @@
           </div>
         <% end %>
             </div>
-              <div class="text-messages">
-                <%= markdown(message.sentence) %>
-              </div>
+            <div class="text-messages">
+              <%= markdown(message.sentence) %>
+            </div>
           </div>
       </div>
     <% end %>

--- a/chatapp/app/views/room/_messages.html.erb
+++ b/chatapp/app/views/room/_messages.html.erb
@@ -37,7 +37,9 @@
           </div>
         <% end %>
             </div>
+            <div class=text-messeges>
               <p><%= markdown(message.sentence) %></p>
+            </div>
           </div>
       </div>
     <% end %>


### PR DESCRIPTION
チャット画面にmarkdownで出力される画像の大きさを小さく変更しました。
そのまま小さくしようとした場合チャット画面内にあるユーザーアイコンもimgなので同じく小さくなってしまうため、
ユーザーアイコンのイメージとチャット内のイメージを分割するために、チャット内の img は text-image という class で囲いました。